### PR TITLE
Fixed compile error for CanvasRenderingContext2D with new version of LightWeightCharts

### DIFF
--- a/src/api/box-api.ts
+++ b/src/api/box-api.ts
@@ -1,0 +1,23 @@
+import { BoxOptions } from '../model/box-options';
+import { CustomBox } from '../model/custom-box';
+
+import { IBox } from './ibox';
+
+export class Box implements IBox {
+	private readonly _box: CustomBox;
+
+	public constructor(box: CustomBox) {
+		this._box = box;
+	}
+
+	public applyOptions(options: Partial<BoxOptions>): void {
+		this._box.applyOptions(options);
+	}
+	public options(): Readonly<BoxOptions> {
+		return this._box.options();
+	}
+
+	public box(): CustomBox {
+		return this._box;
+	}
+}

--- a/src/api/data-validators.ts
+++ b/src/api/data-validators.ts
@@ -1,5 +1,5 @@
 import { assert } from '../helpers/assertions';
-
+import { BoxOptions } from '../model/box-options';
 import { CreatePriceLineOptions } from '../model/price-line-options';
 import { SeriesMarker } from '../model/series-markers';
 import { SeriesType } from '../model/series-options';
@@ -15,6 +15,20 @@ export function checkPriceLineOptions(options: CreatePriceLineOptions): void {
 
 	// eslint-disable-next-line @typescript-eslint/tslint/config
 	assert(typeof options.price === 'number', `the type of 'price' price line's property must be a number, got '${typeof options.price}'`);
+}
+export function checkBoxOptions(options: BoxOptions): void {
+	if (process.env.NODE_ENV === 'production') {
+		return;
+	}
+
+	if (options.corners.length === 0) {
+		// eslint-disable-next-line @typescript-eslint/tslint/config
+		assert(typeof options.lowPrice === 'number', `the type of 'lowPrice' box's property must be a number, got '${typeof options.lowPrice}'`);
+		// eslint-disable-next-line @typescript-eslint/tslint/config
+		assert(typeof options.highPrice === 'number', `the type of 'highPrice' box's property must be a number, got '${typeof options.highPrice}'`);
+	} else {
+		assert(options.corners.length !== 1, `at least 2 corners must be specified, but only got 1 corner`);
+	}
 }
 
 export function checkItemsAreOrdered(data: readonly (SeriesMarker<Time> | SeriesDataItemTypeMap[SeriesType])[], allowDuplicates: boolean = false): void {

--- a/src/api/ibox.ts
+++ b/src/api/ibox.ts
@@ -1,0 +1,38 @@
+import { BoxOptions } from '../model/box-options';
+
+/**
+ * Represents the interface for interacting with boxes.
+ */
+export interface IBox {
+	/**
+	 * Apply options to the box.
+	 *
+	 * @param options - Any subset of options.
+	 * @example
+	 * ```js
+	 * box.applyOptions({
+	 *     corners: [
+	 *         { time: 1641240000, price: 80 },
+	 *         { time: 1641040000, price: 70 },
+	 *     ],
+	 *     lowPrice: 80.0,
+	 *     highPrice: 90.0,
+	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00
+	 *     lateTime: 1641250000, // 2022-01-03 22:46:40
+	 *     borderColor: '#0ff',
+	 *     borderWidth: 1,
+	 *     borderStyle: LightweightCharts.LineStyle.Solid,
+	 *     fillColor: '#0ff',
+	 *     fillOpacity: 0.5,
+	 *     borderVisible: true,
+	 *     axisLabelVisible: false,
+	 *     title: 'My box',
+	 * });
+	 * ```
+	 */
+	applyOptions(options: Partial<BoxOptions>): void;
+	/**
+	 * Get the currently applied options.
+	 */
+	options(): Readonly<BoxOptions>;
+}

--- a/src/api/iseries-api.ts
+++ b/src/api/iseries-api.ts
@@ -1,5 +1,6 @@
+import { IBox } from './ibox';
 import { IPriceFormatter } from '../formatters/iprice-formatter';
-
+import { BoxOptions } from '../model/box-options';
 import { BarPrice } from '../model/bar';
 import { Coordinate } from '../model/coordinate';
 import { MismatchDirection } from '../model/plot-list';
@@ -248,6 +249,46 @@ export interface ISeriesApi<TSeriesType extends SeriesType> {
 	 * ```
 	 */
 	removePriceLine(line: IPriceLine): void;
+
+		/**
+	 * Creates a new box.
+	 *
+	 * @param options - Any subset of options.
+	 * @example
+	 * ```js
+	 * box.applyOptions({
+	 *     corners: [
+	 *         { time: 1641240000, price: 80 },
+         *         { time: 1641040000, price: 70 },
+	 *     ],
+	 *     lowPrice: 80.0,
+	 *     highPrice: 90.0,
+	 *     earlyTime: 1641240000, // 2022-01-03 20:00:00
+	 *     lateTime: 1641250000, // 2022-01-03 22:46:40
+	 *     borderColor: '#0ff',
+	 *     borderWidth: 1,
+	 *     borderStyle: LightweightCharts.LineStyle.Solid,
+	 *     fillColor: '#0ff',
+	 *     fillOpacity: 50,
+	 *     borderVisible: true,
+	 *     axisLabelVisible: false,
+	 *     title: 'My box',
+	 * });
+	 * ```
+	 */
+		createBox(options: BoxOptions): IBox;
+
+		/**
+		 * Removes the box that was created before.
+		 *
+		 * @param box - A box to remove.
+		 * @example
+		 * ```js
+		 * const box = series.createBox({ lowPrice: 80.0 });
+		 * series.removeBox(box);
+		 * ```
+		 */
+		removeBox(box: IBox): void;
 
 	/**
 	 * Return current series type.

--- a/src/api/options/box-options-defaults.ts
+++ b/src/api/options/box-options-defaults.ts
@@ -1,0 +1,18 @@
+import { BoxOptions } from '../../model/box-options';
+import { LineStyle } from '../../renderers/draw-line';
+
+export const boxOptionsDefaults: BoxOptions = {
+	corners: [],
+	lowPrice: 0.0,
+	highPrice: 0.0,
+	earlyTime: 0,
+	lateTime: 0,
+	borderColor: '#0FF',
+	borderWidth: 1,
+	borderStyle: LineStyle.Solid,
+	fillColor: '#0FF',
+	fillOpacity: 1,
+	borderVisible: true,
+	axisLabelVisible: false,
+	title: '',
+};

--- a/src/api/series-api.ts
+++ b/src/api/series-api.ts
@@ -17,17 +17,20 @@ import {
 } from '../model/series-options';
 import { Logical, OriginalTime, Range, Time, TimePoint, TimePointIndex } from '../model/time-data';
 import { TimeScaleVisibleRange } from '../model/time-scale-visible-range';
-
+import { BoxOptions } from '../model/box-options';
 import { IPriceScaleApiProvider } from './chart-api';
 import { DataUpdatesConsumer, SeriesDataItemTypeMap } from './data-consumer';
 import { convertTime } from './data-layer';
-import { checkItemsAreOrdered, checkPriceLineOptions, checkSeriesValuesType } from './data-validators';
 import { getSeriesDataCreator } from './get-series-data-creator';
 import { IPriceLine } from './iprice-line';
 import { IPriceScaleApi } from './iprice-scale-api';
 import { BarsInfo, ISeriesApi } from './iseries-api';
 import { priceLineOptionsDefaults } from './options/price-line-options-defaults';
 import { PriceLine } from './price-line-api';
+import { Box } from './box-api';
+import { checkBoxOptions, checkItemsAreOrdered, checkPriceLineOptions, checkSeriesValuesType } from './data-validators';
+import { IBox } from './ibox';
+import { boxOptionsDefaults } from './options/box-options-defaults';
 
 export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSeriesType> {
 	protected _series: Series<TSeriesType>;
@@ -180,6 +183,19 @@ export class SeriesApi<TSeriesType extends SeriesType> implements ISeriesApi<TSe
 
 	public removePriceLine(line: IPriceLine): void {
 		this._series.removePriceLine((line as PriceLine).priceLine());
+	}
+
+	public createBox(options: BoxOptions): IBox {
+		const strictOptions = merge(clone(boxOptionsDefaults), options) as BoxOptions;
+		checkBoxOptions(strictOptions);
+
+		const box = this._series.createBox(strictOptions);
+
+		return new Box(box);
+	}
+
+	public removeBox(box: IBox): void {
+		this._series.removeBox((box as Box).box());
 	}
 
 	public seriesType(): TSeriesType {

--- a/src/model/box-options.ts
+++ b/src/model/box-options.ts
@@ -1,0 +1,86 @@
+import { UserPoint } from '../model/point';
+import { LineStyle, LineWidth } from '../renderers/draw-line';
+
+/**
+ * Represents a box options.
+ */
+export interface BoxOptions {
+	/**
+	 * Corners of the shape.
+	 *
+	 * @defaultValue `[]`
+	 */
+	corners: UserPoint[];
+	/**
+	 * Line: bottom.
+	 *
+	 * @defaultValue `0`
+	 */
+	lowPrice: number;
+	/**
+	 * Line: top.
+	 *
+	 * @defaultValue `0`
+	 */
+	highPrice: number;
+	/**
+	 * Line: left.
+	 *
+	 * @defaultValue `0`
+	 */
+	earlyTime: number;
+	/**
+	 * Line: right.
+	 *
+	 * @defaultValue `0`
+	 */
+	lateTime: number;
+	/**
+	 * Border color.
+	 *
+	 * @defaultValue `''`
+	 */
+	borderColor: string;
+	/**
+	 * Border width in pixels.
+	 *
+	 * @defaultValue `1`
+	 */
+	borderWidth: LineWidth;
+	/**
+	 * Border style.
+	 *
+	 * @defaultValue {@link LineStyle.Solid}
+	 */
+	borderStyle: LineStyle;
+	/**
+	 * Fill color.
+	 *
+	 * @defaultValue `''`
+	 */
+	fillColor: string;
+	/**
+	 * Fill opacity.
+	 *
+	 * @defaultValue `1`
+	 */
+	fillOpacity: number;
+	/**
+	 * Display border.
+	 *
+	 * @defaultValue `true`
+	 */
+	borderVisible: boolean;
+	/**
+	 * Display the current price value in on the price scale.
+	 *
+	 * @defaultValue `false`
+	 */
+	axisLabelVisible: boolean;
+	/**
+	 * Price line's on the chart pane.
+	 *
+	 * @defaultValue `''`
+	 */
+	title: string;
+}

--- a/src/model/custom-box.ts
+++ b/src/model/custom-box.ts
@@ -1,0 +1,103 @@
+import { merge } from '../helpers/strict-type-checks';
+
+import { CustomBoxPaneView } from '../views/pane/custom-box-pane-view';
+import { IPaneView } from '../views/pane/ipane-view';
+// TODO: show prices for box Y coords
+// import { PanePriceAxisView } from '../views/pane/pane-price-axis-view';
+// import { CustomPriceLinePriceAxisView } from '../views/price-axis/custom-price-line-price-axis-view';
+// import { IPriceAxisView } from '../views/price-axis/iprice-axis-view';
+
+import { BoxOptions } from './box-options';
+import { Coordinate } from './coordinate';
+import { Series } from './series';
+import { UTCTimestamp } from './time-data';
+
+export class CustomBox {
+	private readonly _series: Series;
+	private readonly _boxView: CustomBoxPaneView;
+	// private readonly _priceAxisView: CustomPriceLinePriceAxisView;
+	// private readonly _panePriceAxisView: PanePriceAxisView;
+	private readonly _options: BoxOptions;
+
+	public constructor(series: Series, options: BoxOptions) {
+		this._series = series;
+		this._options = options;
+		this._boxView = new CustomBoxPaneView(series, this);
+		// this._priceAxisView = new CustomPriceLinePriceAxisView(series, this);
+		// this._panePriceAxisView = new PanePriceAxisView(this._priceAxisView, series, series.model());
+	}
+
+	public applyOptions(options: Partial<BoxOptions>): void {
+		merge(this._options, options);
+		this.update();
+		this._series.model().lightUpdate();
+	}
+
+	public options(): BoxOptions {
+		return this._options;
+	}
+
+	public paneView(): IPaneView {
+		return this._boxView;
+	}
+
+	// public labelPaneView(): IPaneView {
+	// 	return this._panePriceAxisView;
+	// }
+
+	// public priceAxisView(): IPriceAxisView {
+	// 	return this._priceAxisView;
+	// }
+
+	public update(): void {
+		this._boxView.update();
+		// this._priceAxisView.update();
+	}
+
+	public xLowCoord(): Coordinate | null {
+		return this.xCoord(this._options.earlyTime as UTCTimestamp);
+	}
+
+	public xHighCoord(): Coordinate | null {
+		return this.xCoord(this._options.lateTime as UTCTimestamp);
+	}
+
+	public yLowCoord(): Coordinate | null {
+		// low Y coord = the high price (it is intentionally flipped)
+		return this.yCoord(this._options.highPrice);
+	}
+
+	public yHighCoord(): Coordinate | null {
+		// high Y coord = the low price (it is intentionally flipped)
+		return this.yCoord(this._options.lowPrice);
+	}
+
+	public xCoord(time: UTCTimestamp): Coordinate | null {
+		const series = this._series;
+		const timeScale = series.model().timeScale();
+		const timeIndex = timeScale.timeToIndex({ timestamp: time }, true);
+
+		if (timeScale.isEmpty() || timeIndex === null) {
+			return null;
+		}
+
+		return timeScale.indexToCoordinate(timeIndex);
+	}
+
+	public yCoord(price: number): Coordinate | null {
+		const series = this._series;
+		const priceScale = series.priceScale();
+		const timeScale = series.model().timeScale();
+
+		if (timeScale.isEmpty() || priceScale.isEmpty()) {
+			return null;
+		}
+
+		const firstValue = series.firstValue();
+		if (firstValue === null) {
+			return null;
+		}
+
+		return priceScale.priceToCoordinate(price, firstValue.value);
+	}
+}

--- a/src/model/point.ts
+++ b/src/model/point.ts
@@ -1,5 +1,6 @@
 import { Coordinate } from './coordinate';
 
+
 /**
  * Represents a point on the chart.
  */
@@ -12,4 +13,17 @@ export interface Point {
 	 * The y coordinate.
 	 */
 	readonly y: Coordinate;
+}
+/**
+ * Represents a point input from the user.
+ */
+export interface UserPoint {
+	/**
+	 * The x coordinate.
+	 */
+	readonly time: number;
+	/**
+	 * The y coordinate.
+	 */
+	readonly price: number;
 }

--- a/src/renderers/box-renderer.ts
+++ b/src/renderers/box-renderer.ts
@@ -1,0 +1,136 @@
+import { Coordinate } from '../model/coordinate';
+import { Point } from '../model/point';
+import { CanvasRenderingTarget2D, MediaCoordinatesRenderingScope } from 'fancy-canvas';
+import { LineStyle, LineWidth, setLineStyle } from './draw-line';
+import { IPaneRenderer } from './ipane-renderer';
+import { ensureNotNull } from '../helpers/assertions';
+
+export interface BoxRendererData {
+	fillColor: string;
+	fillOpacity: number;
+	borderColor: string;
+	borderStyle: LineStyle;
+	borderWidth: LineWidth;
+	borderVisible: boolean;
+
+	corners: Point[];
+	xLow: Coordinate; // earlyTime
+	xHigh: Coordinate; // lateTime
+	yLow: Coordinate; // lowPrice
+	yHigh: Coordinate; // highPrice
+	visible?: boolean;
+
+	// axisLabelVisible
+	// title
+	width: number; // Canvas width?
+	height: number; // Canvas height?
+}
+
+export class BoxRenderer implements IPaneRenderer {
+	public _data: BoxRendererData | null ;
+
+	public constructor() {
+		this._data = null;
+	}
+	public setData(data: BoxRendererData): void {
+		this._data = data;
+	}
+
+	//CanvasRenderingContext2D
+	public draw(target: CanvasRenderingTarget2D,isHovered: boolean, hitTestData?: unknown): void {
+		if (this._data === null || this._data.visible === false ) {
+			return;
+		}
+		const  pixelRatio: number = 1
+		if (this._data === null) {
+			return;
+		}
+		target.useMediaCoordinateSpace(({ context: ctx }: MediaCoordinatesRenderingScope) => {
+			ensureNotNull(this._data).width = ctx.canvas.width;
+			ensureNotNull(this._data).height = ctx.canvas.height;
+		})
+
+		let corners: Point[] = [];
+
+		if (this._data.corners.length === 0) {
+			const height = Math.ceil(this._data.height * pixelRatio);
+			const yLow = Math.round(this._data.yLow * pixelRatio) as Coordinate;
+			if (yLow > height) {
+				return;
+			}
+
+			const yHigh = Math.round(this._data.yHigh * pixelRatio) as Coordinate;
+
+			if (yHigh < 0) {
+				return;
+			}
+
+			const width = Math.ceil(this._data.width * pixelRatio);
+			const xLow = Math.round(this._data.xLow * pixelRatio) as Coordinate;
+			if (xLow > width) {
+				return;
+			}
+
+			const xHigh = Math.round(this._data.xHigh * pixelRatio) as Coordinate;
+			if (xHigh < 0) {
+				return;
+			}
+
+			corners = [
+				{ x: xLow, y: yLow },
+				{ x: xLow, y: yHigh },
+				{ x: xHigh, y: yHigh },
+				{ x: xHigh, y: yLow },
+			];
+
+		} else {
+			for (let i = 0; i < this._data.corners.length; ++i) {
+				corners.push({
+					x: Math.round(this._data.corners[i].x * pixelRatio) as Coordinate,
+					y: Math.round(this._data.corners[i].y * pixelRatio) as Coordinate,
+				});
+			}
+		}
+		target.useMediaCoordinateSpace(({ context: ctx }: MediaCoordinatesRenderingScope) => {
+		//	ctx.font = rendererOptions.font;
+			//return Math.round(rendererOptions.widthCache.measureText(ctx, ensureNotNull(this._data).text, optimizationReplacementRe));
+		ctx.beginPath();
+		ctx.moveTo(corners[corners.length - 1].x, corners[corners.length - 1].y);
+
+		for (let i = 0; i < corners.length; ++i) {
+			ctx.lineTo(corners[i].x, corners[i].y);
+		}
+
+		ctx.fillStyle = this._hexToRgba(ensureNotNull(this._data).fillColor, ensureNotNull(this._data).fillOpacity);
+		ctx.fill();
+
+		if (ensureNotNull(this._data).borderVisible) {
+			ctx.strokeStyle = ensureNotNull(this._data).borderColor;
+			ctx.lineWidth = ensureNotNull(this._data).borderWidth;
+			setLineStyle(ctx, ensureNotNull(this._data).borderStyle);
+		} else { // border will default to a thin black line without the following
+			ctx.lineWidth = 0.00001;
+			ctx.strokeStyle = this._hexToRgba(ensureNotNull(this._data).fillColor, ensureNotNull(this._data).fillOpacity);
+			
+		}
+
+		ctx.stroke();
+		});
+
+		
+	}
+
+	private _hexToRgba(hex: string, opacity: number): string {
+		hex = hex.substring(1);
+
+		if (hex.length === 3) {
+			hex = `${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`;
+		}
+
+		const r = parseInt(hex.substring(0, 2), 16);
+		const g = parseInt(hex.substring(2, 4), 16);
+		const b = parseInt(hex.substring(4, 6), 16);
+
+		return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+	}
+}

--- a/src/views/pane/custom-box-pane-view.ts
+++ b/src/views/pane/custom-box-pane-view.ts
@@ -1,0 +1,69 @@
+import { CustomBox } from '../../model/custom-box';
+import { Series } from '../../model/series';
+import { UTCTimestamp } from '../../model/time-data';
+
+import { SeriesBoxPaneView } from './series-box-pane-view';
+
+export class CustomBoxPaneView extends SeriesBoxPaneView {
+	private readonly _box: CustomBox;
+
+	public constructor(series: Series, box: CustomBox) {
+		super(series);
+		this._box = box;
+	}
+
+	protected _updateImpl(height: number, width: number): void {
+		const data = this._boxRendererData;
+		const boxOptions = this._box.options();
+
+		data.visible = false;
+
+		if (!this._series.visible()) {
+			return;
+		}
+
+		data.fillColor = boxOptions.fillColor;
+		data.fillOpacity = boxOptions.fillOpacity;
+		data.borderColor = boxOptions.borderColor;
+		data.borderStyle = boxOptions.borderStyle;
+		data.borderWidth = boxOptions.borderWidth;
+		data.borderVisible = boxOptions.borderVisible;
+		data.corners = [];
+		data.visible = true;
+
+		data.width = width;
+		data.height = height;
+
+		if (boxOptions.corners.length === 0) {
+			const yLow = this._box.yLowCoord();
+			const yHigh = this._box.yHighCoord();
+
+			if (yLow === null || yHigh === null) {
+				return;
+			}
+
+			const xLow = this._box.xLowCoord();
+			const xHigh = this._box.xHighCoord();
+
+			if (xLow === null || xHigh === null) {
+				return;
+			}
+
+			data.xLow = xLow;
+			data.xHigh = xHigh;
+			data.yLow = yLow;
+			data.yHigh = yHigh;
+		} else {
+			for (let i = 0; i < boxOptions.corners.length; ++i) {
+				const x = this._box.xCoord(boxOptions.corners[i].time as UTCTimestamp);
+				const y = this._box.yCoord(boxOptions.corners[i].price);
+
+				if (x === null || y === null) {
+					return;
+				}
+
+				data.corners.push({ x: x, y: y });
+			}
+		}
+	}
+}

--- a/src/views/pane/series-box-pane-view.ts
+++ b/src/views/pane/series-box-pane-view.ts
@@ -1,0 +1,58 @@
+import { ChartModel } from '../../model/chart-model';
+import { Coordinate } from '../../model/coordinate';
+import { Series } from '../../model/series';
+import { BoxRenderer, BoxRendererData } from '../../renderers/box-renderer';
+import { LineStyle } from '../../renderers/draw-line';
+import { IPaneRenderer } from '../../renderers/ipane-renderer';
+
+import { IPaneView } from './ipane-view';
+
+export abstract class SeriesBoxPaneView implements IPaneView {
+	protected readonly _boxRendererData: BoxRendererData = {
+		fillColor: '#000',
+		fillOpacity: 1,
+		borderColor: '#000',
+		borderStyle: LineStyle.Solid,
+		borderWidth: 1,
+		borderVisible: false,
+		corners: [],
+		xLow: 0 as Coordinate,
+		xHigh: 0 as Coordinate,
+		yLow: 0 as Coordinate,
+		yHigh: 0 as Coordinate,
+		visible: false,
+
+		width: 0,
+		height: 0,
+	};
+
+	protected readonly _series: Series;
+	protected readonly _model: ChartModel;
+	protected readonly _boxRenderer: BoxRenderer = new BoxRenderer();
+	private _invalidated: boolean = true;
+
+	protected constructor(series: Series) {
+		this._series = series;
+		this._model = series.model();
+		this._boxRenderer.setData(this._boxRendererData);
+	}
+
+	public update(): void {
+		this._invalidated = true;
+	}
+
+	public renderer(): IPaneRenderer | null {
+		if (!this._series.visible()) {
+			return null;
+		}
+
+		if (this._invalidated) {
+			this._updateImpl(this._boxRendererData.height, this._boxRendererData.width);
+			this._invalidated = false;
+		}
+		this._boxRenderer.setData(this._boxRendererData);
+		return this._boxRenderer;
+	}
+
+	protected abstract _updateImpl(height: number, width: number): void;
+}

--- a/website/tutorials/customization/assets/step1.html
+++ b/website/tutorials/customization/assets/step1.html
@@ -10,7 +10,7 @@
     <!-- Adding the standalone version of Lightweight charts -->
     <script
       type="text/javascript"
-      src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"
+      src="../../../../dist/lightweight-charts.standalone.development.js"
     ></script>
     <style>
       body {
@@ -1087,6 +1087,23 @@
       const mainSeries = chart.addCandlestickSeries();
       // Set the data for the Main Series
       mainSeries.setData(candleStickData);
+
+      const box = {
+      lowPrice: 170.0,
+      highPrice: 197.0,
+      earlyTime: 1539980962,
+      lateTime: 1746589257,
+      borderColor: '#00008B',
+      borderWidth: 2,
+      borderStyle: LightweightCharts.LineStyle.Solid,
+      fillColor: '#0ff',
+      fillOpacity: 0.1,
+      borderVisible: false,
+      axisLabelVisible: false,
+      title: 'My box',
+    };
+
+    const createdBox = mainSeries.createBox(box);
 
       // Adding a window resize event handler to resize the chart when
       // the window size changes.


### PR DESCRIPTION
Kudos to the original code - https://github.com/tradingview/lightweight-charts/pull/1064

Original PR was throwing compilation errors with latest version of LightWeight Charts. 


![image](https://user-images.githubusercontent.com/2816651/222931135-590afaa0-8d71-4561-ac38-58462230ba95.png)
